### PR TITLE
updated docs with stellar official docs

### DIFF
--- a/models/descriptions/tables/dim_assets.md
+++ b/models/descriptions/tables/dim_assets.md
@@ -1,0 +1,7 @@
+{% docs core__dim_assets %}
+
+Table reports which assets are used during the batch interval, which can help identify periods of time of large activity for an asset. The table does not have a primary key and assets are duplicated in the table as they are used during different periods of time. To get a distinct count of assets on the network, please refer to the history_assets table. Table not widely used.
+
+Learn more about Stellar assets: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/assets
+
+{% enddocs %}

--- a/models/descriptions/tables/ez_operations.md
+++ b/models/descriptions/tables/ez_operations.md
@@ -1,0 +1,7 @@
+{% docs core__ez_operations %}
+
+An aggregated convenience table that joins `core.fact_operations`, `core.fact_transactions`, and `core.fact_ledgers`.
+
+Learn more about Stellar data structures: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures
+
+{% enddocs %}

--- a/models/descriptions/tables/fact_accounts.md
+++ b/models/descriptions/tables/fact_accounts.md
@@ -1,0 +1,7 @@
+{% docs core__fact_accounts %}
+
+The accounts table stores detailed information for a given account, including current account status, preconditions for transaction authorization, security settings and account balance. The balance reported in the accounts table reflects the account’s XLM balance only. All other asset balances are reported in the 'trust_lines' table. Any changes to the account, whether it is an account settings change, balance increase/decrease or sponsorship change will result in an increase to the account sequence_number and last_modified_ledger. The sequence_number is incremented with each operation applied to an account so that order is preserved during account mutation.
+
+Learn more about Stellar accounts: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts
+
+{% enddocs %}

--- a/models/descriptions/tables/fact_contract_events.md
+++ b/models/descriptions/tables/fact_contract_events.md
@@ -1,0 +1,7 @@
+{% docs core__fact_contract_events %}
+
+This table contains all contract events, diagnostic events, and system events. Events cover a wide variety of information including token value movement, core metrics, and logging/debugging information.
+
+Learn more about Stellar smart contracts: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/contracts
+
+{% enddocs %}

--- a/models/descriptions/tables/fact_ledgers.md
+++ b/models/descriptions/tables/fact_ledgers.md
@@ -1,0 +1,7 @@
+{% docs core__fact_ledgers %}
+
+Each ledger stores the state of the network at a given point in time and contains all changes applied to the network - transactions, operations, etc. This table summarizes the actions taken within a single ledger and is relevant in determining high level network conditions.
+
+Learn more about Stellar ledgers: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/ledgers
+
+{% enddocs %}

--- a/models/descriptions/tables/fact_liquidity_pools.md
+++ b/models/descriptions/tables/fact_liquidity_pools.md
@@ -1,0 +1,8 @@
+{% docs defi__fact_liquidity_pools %}
+
+Stellar rolled out Automated Market Makers to its network in Nov 2021, which improves liquidity between asset pairs while incentivizing users to stake money in pools. Liquidity pools provide a simple, non-interactive way to trade large amounts of capital and enable high volumes of trading. Liquidity pools can be created between asset pairs and algorithmically controls the supply of the assets to give the best exchange rate while not requiring an orderbook in order to execute the trade. For each trade executed through a liquidity pool, the users with staked liquidity in the pool earn fees, which are distributed automatically to their accounts. Users can deposit and withdraw money in the pools; trades only execute via path payment operation.
+
+Learn more about Stellar data concepts: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures
+
+{% enddocs %}
+

--- a/models/descriptions/tables/fact_operations.md
+++ b/models/descriptions/tables/fact_operations.md
@@ -1,0 +1,7 @@
+{% docs core__fact_operations %}
+
+This table contains the lowest granularity of data avaiable to the network. It contains all details regarding operations that were executed as part of a transaction set. Be careful - the table contains both failed and successful operations. The details record will return varying information about an operation according to the operation type.
+
+Learn more about Stellar operations: https://developers.stellar.org/docs/learn/fundamentals/transactions/operations-and-transactions
+
+{% enddocs %}

--- a/models/descriptions/tables/fact_trades.md
+++ b/models/descriptions/tables/fact_trades.md
@@ -1,0 +1,8 @@
+{% docs defi__fact_trades %}
+
+This table reports trading activity that occurs in both the decentralized exchange and automated money markets. Trades fulfill one of four operations: manage buy offers, manage sell offers and path payments (strict send and receive). Trades can be executed either against the orderbook or a liquidity pool that contains both bid and ask asset pair. Trades can be either path payments or offers that are fully or partially fulfilled, which means that the trade can be split into segments. A full trade is compromised of all "order" numbers for a given history_operation_id.
+
+Learn more about Stellar data concepts: https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures
+
+{% enddocs %}
+

--- a/models/descriptions/tables/fact_transactions.md
+++ b/models/descriptions/tables/fact_transactions.md
@@ -1,0 +1,7 @@
+{% docs core__fact_transactions %}
+
+Transactions are commands that modify the ledger state and consist of one or more operations. In terms of taxonomy, a ledger contains a transaction set of multiple transactions, and a transaction contains an operation set of one to many operations. Transactions that are sent to the Stellar Network either succeed completely or fail completely. There is no partial transaction execution. The table is an event log of all transactions submitted and committed to a transaction set within a ledger.
+
+Learn more about Stellar transactions: https://developers.stellar.org/docs/learn/fundamentals/transactions/operations-and-transactions
+
+{% enddocs %}

--- a/models/gold/core/core__dim_assets.yml
+++ b/models/gold/core/core__dim_assets.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__dim_assets
-    description: Dimension table containing information about assets on the network.
+    description: "{{ doc('core__dim_assets') }}"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/models/gold/core/core__fact_accounts.yml
+++ b/models/gold/core/core__fact_accounts.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__fact_accounts
-    description: Core fact table containing all Stellar account information and their current states
+    description: "{{ doc('core__fact_accounts') }}"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/models/gold/core/core__fact_contract_events.yml
+++ b/models/gold/core/core__fact_contract_events.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__fact_contract_events
-    description: Fact table containing contract event details from the Stellar network.
+    description: "{{ doc('core__fact_contract_events') }}"
     columns:
 
       - name: TRANSACTION_HASH

--- a/models/gold/core/core__fact_ledgers.yml
+++ b/models/gold/core/core__fact_ledgers.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__fact_ledgers
-    description: Fact table containing information about ledgers on the Stellar network.
+    description: "{{ doc('core__fact_ledgers') }}"
     columns:
       - name: SEQUENCE
         description: '{{ doc("sequence") }}'

--- a/models/gold/core/core__fact_operations.yml
+++ b/models/gold/core/core__fact_operations.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__fact_operations
-    description: A comprehensive view of all operations executed on the Stellar network, including transaction details, operation types, and their outcomes.
+    description: "{{ doc('core__fact_operations') }}"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__fact_transactions
-    description: Fact table containing transaction details from the Stellar network.
+    description: "{{ doc('core__fact_transactions') }}"
     columns:
 
       - name: ID

--- a/models/gold/defi/defi__fact_liquidity_pools.yml
+++ b/models/gold/defi/defi__fact_liquidity_pools.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: defi__fact_liquidity_pools
-    description: Fact table containing liquidity pool data including pool details, asset pairs, and metrics.
+    description: "{{ doc('defi__fact_liquidity_pools') }}"
     
     columns:
 

--- a/models/gold/defi/defi__fact_trades.yml
+++ b/models/gold/defi/defi__fact_trades.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: defi__fact_trades
-    description: A fact table containing trade execution details from both the decentralized exchange and liquidity pools.
+    description: "{{ doc('defi__fact_trades') }}"
     columns:
       - name: history_operation_id
         description: '{{ doc("history_operation_id") }}'

--- a/models/gold/operations/core__ez_operations.yml
+++ b/models/gold/operations/core__ez_operations.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: core__ez_operations
-    description: A comprehensive view combining operations with their associated transaction and ledger data.
+    description: "{{ doc('core__ez_operations') }}"
     columns:
 
       - name: OP_ID


### PR DESCRIPTION
- Pulled more descriptive table docs from Hubble's dbt docs ([example](http://www.stellar-dbt-docs.com/#!/source/source.stellar_dbt_public.crypto_stellar.history_trades))
- Added URL links to the most relevant pages on the Stellar [official docs](https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures)

I tested this out with a `dbt docs generate && dbt docs serve`. Don't think anything else is required to update in Studio.